### PR TITLE
Update slurm_kempner_node_status_collector.py

### DIFF
--- a/slurm_kempner_node_status_collector.py
+++ b/slurm_kempner_node_status_collector.py
@@ -69,7 +69,7 @@ class SlurmClusterStatusCollector:
     def update_state_counters(self, node, cfgtres, alloctres):
         """Update the counters based on the node's state."""
         state = node['State']
-        for status in ["IDLE", "MIXED", "ALLOC", "RESE", "COMP", "DRAIN", "DOWN"]:
+        for status in ["IDLE", "MIXED", "ALLOC", "RES", "COMP", "DRAIN", "DOWN"]:
             if status in state:
                 self.metrics[f"{status}Tot"] += 1
                 self.metrics[f"{status}CPU"] += int(node['CPUTot'])


### PR DESCRIPTION
Minor bug fix to the script "slurm_kempner_node_status_collector.py". The metric RES for reservation was incorrectly specified as RESE. Now fixed.